### PR TITLE
leveldb: implement concurrent compaction

### DIFF
--- a/leveldb/db_compaction.go
+++ b/leveldb/db_compaction.go
@@ -164,7 +164,7 @@ func (db *DB) compactionTransact(name string, t compactionTransactInterface) {
 	const (
 		backoffMin = 1 * time.Second
 		backoffMax = 8 * time.Second
-		backoffMul = 2 * time.Second
+		backoffMul = 2
 	)
 	var (
 		backoff  = backoffMin

--- a/leveldb/db_compaction.go
+++ b/leveldb/db_compaction.go
@@ -7,6 +7,7 @@
 package leveldb
 
 import (
+	"sort"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -167,11 +168,16 @@ func (db *DB) compactionTransact(name string, t compactionTransactInterface) {
 	)
 	var (
 		backoff  = backoffMin
-		backoffT = time.NewTimer(backoff)
+		backoffT *time.Timer
 		lastCnt  = compactionTransactCounter(0)
 
 		disableBackoff = db.s.o.GetDisableCompactionBackoff()
 	)
+	defer func() {
+		if backoffT != nil {
+			backoffT.Stop()
+		}
+	}()
 	for n := 0; ; n++ {
 		// Check whether the DB is closed.
 		if db.isClosed() {
@@ -216,7 +222,11 @@ func (db *DB) compactionTransact(name string, t compactionTransactInterface) {
 			}
 
 			// Backoff.
-			backoffT.Reset(backoff)
+			if backoffT == nil {
+				backoffT = time.NewTimer(backoff)
+			} else {
+				backoffT.Reset(backoff)
+			}
 			if backoff < backoffMax {
 				backoff *= backoffMul
 				if backoff > backoffMax {
@@ -265,6 +275,33 @@ func (db *DB) compactionCommit(name string, rec *sessionRecord) {
 	}, nil)
 }
 
+func (db *DB) pauseTableCompaction() {
+	var resumeCh <-chan struct{}
+noPause:
+	for {
+		select {
+		case resumeCh = <-db.tcompPauseSetC:
+			goto hasPause
+		case <-db.closeC:
+			return
+		}
+	}
+hasPause:
+	for {
+		select {
+		case ch := <-db.tcompPauseSetC:
+			if ch != nil {
+				panic("invalid resume channel")
+			}
+			resumeCh = nil
+			goto noPause
+		case db.tcompPauseC <- resumeCh:
+		case <-db.closeC:
+			return
+		}
+	}
+}
+
 func (db *DB) memCompaction() {
 	mdb := db.getFrozenMem()
 	if mdb == nil {
@@ -285,10 +322,7 @@ func (db *DB) memCompaction() {
 	// Pause table compaction.
 	resumeC := make(chan struct{})
 	select {
-	case db.tcompPauseC <- (chan<- struct{})(resumeC):
-	case <-db.compPerErrC:
-		close(resumeC)
-		resumeC = nil
+	case db.tcompPauseSetC <- (<-chan struct{})(resumeC):
 	case <-db.closeC:
 		db.compactionExitTransact()
 	}
@@ -336,14 +370,13 @@ func (db *DB) memCompaction() {
 	db.dropFrozenMem()
 
 	// Resume table compaction.
-	if resumeC != nil {
-		select {
-		case <-resumeC:
-			close(resumeC)
-		case <-db.closeC:
-			db.compactionExitTransact()
-		}
+	select {
+	case db.tcompPauseSetC <- nil:
+	case <-db.closeC:
+		db.compactionExitTransact()
 	}
+	close(resumeC)
+	resumeC = nil
 
 	// Trigger table compaction.
 	db.compTrigger(db.tcompCmdC)
@@ -377,15 +410,15 @@ func (b *tableCompactionBuilder) appendKV(key, value []byte) error {
 	// Create new table if not already.
 	if b.tw == nil {
 		// Check for pause event.
-		if b.db != nil {
-			select {
-			case ch := <-b.db.tcompPauseC:
-				b.db.pauseCompaction(ch)
-			case <-b.db.closeC:
-				b.db.compactionExitTransact()
-			default:
-			}
-		}
+		//if b.db != nil {
+		//	select {
+		//	case ch := <-b.db.tcompPauseC:
+		//		b.db.pauseCompaction(ch)
+		//	case <-b.db.closeC:
+		//		b.db.compactionExitTransact()
+		//	default:
+		//	}
+		//}
 
 		// Create new table.
 		var err error
@@ -540,8 +573,13 @@ func (b *tableCompactionBuilder) revert() error {
 	return nil
 }
 
-func (db *DB) tableCompaction(c *compaction, noTrivial bool) {
+func (db *DB) tableCompaction(c *compaction, noTrivial bool, done func(*compaction)) {
 	defer c.release()
+	defer func() {
+		if done != nil {
+			done(c)
+		}
+	}()
 
 	rec := &sessionRecord{}
 	rec.addCompPtr(c.sourceLevel, c.imax)
@@ -605,7 +643,7 @@ func (db *DB) tableRangeCompaction(level int, umin, umax []byte) error {
 	db.logf("table@compaction range L%d %q:%q", level, umin, umax)
 	if level >= 0 {
 		if c := db.s.getCompactionRange(level, umin, umax, true); c != nil {
-			db.tableCompaction(c, true)
+			db.tableCompaction(c, true, nil)
 		}
 	} else {
 		// Retry until nothing to compact.
@@ -625,7 +663,7 @@ func (db *DB) tableRangeCompaction(level int, umin, umax []byte) error {
 
 			for level := 0; level < m; level++ {
 				if c := db.s.getCompactionRange(level, umin, umax, false); c != nil {
-					db.tableCompaction(c, true)
+					db.tableCompaction(c, true, nil)
 					compacted = true
 				}
 			}
@@ -639,16 +677,14 @@ func (db *DB) tableRangeCompaction(level int, umin, umax []byte) error {
 	return nil
 }
 
-func (db *DB) tableAutoCompaction() {
-	if c := db.s.pickCompaction(); c != nil {
-		db.tableCompaction(c, false)
-	}
-}
-
-func (db *DB) tableNeedCompaction() bool {
+// tableNeedCompaction returns the indicator whether system needs compaction.
+// If so, then the relevant level or target table(is nil if the normal table
+// compaction is required) will be returned.
+func (db *DB) tableNeedCompaction(ctx *compactionContext) (needCompact bool, level int, table *tFile) {
 	v := db.s.version()
 	defer v.release()
-	return v.needCompaction()
+
+	return v.needCompaction(ctx)
 }
 
 // resumeWrite returns an indicator whether we should resume write operation if enough level0 files are compacted.
@@ -661,9 +697,9 @@ func (db *DB) resumeWrite() bool {
 	return false
 }
 
-func (db *DB) pauseCompaction(ch chan<- struct{}) {
+func (db *DB) pauseCompaction(ch <-chan struct{}) {
 	select {
-	case ch <- struct{}{}:
+	case <-ch:
 	case <-db.closeC:
 		db.compactionExitTransact()
 	}
@@ -674,8 +710,13 @@ type cCmd interface {
 }
 
 type cAuto struct {
-	// Note for table compaction, an non-empty ackC represents it's a compaction waiting command.
+	// Note for table compaction, an non-empty ackC
+	// represents it's a compaction waiting command.
 	ackC chan<- error
+
+	// Flag whether the ack should only be sent when
+	// all compactions finished. Used for testing only.
+	full bool
 }
 
 func (r cAuto) ack(err error) {
@@ -710,13 +751,36 @@ func (db *DB) compTrigger(compC chan<- cCmd) {
 	}
 }
 
+// This will trigger auto compaction and wait for all compaction to be done.
+// Note it's only used in testing.
+func (db *DB) waitAllTableComp() (err error) {
+	ch := make(chan error)
+	defer close(ch)
+	// Send cmd.
+	select {
+	case db.tcompCmdC <- cAuto{ackC: ch, full: true}:
+	case err = <-db.compErrC:
+		return
+	case <-db.closeC:
+		return ErrClosed
+	}
+	// Wait cmd.
+	select {
+	case err = <-ch:
+	case err = <-db.compErrC:
+	case <-db.closeC:
+		return ErrClosed
+	}
+	return err
+}
+
 // This will trigger auto compaction and/or wait for all compaction to be done.
 func (db *DB) compTriggerWait(compC chan<- cCmd) (err error) {
 	ch := make(chan error)
 	defer close(ch)
 	// Send cmd.
 	select {
-	case compC <- cAuto{ch}:
+	case compC <- cAuto{ackC: ch}:
 	case err = <-db.compErrC:
 		return
 	case <-db.closeC:
@@ -786,80 +850,324 @@ func (db *DB) mCompaction() {
 	}
 }
 
+type compactions []*compaction
+
+// Returns true if i smallest key is less than j.
+// This used for sort by key in ascending order.
+func (cs compactions) lessByKey(icmp *iComparer, i, j int) bool {
+	a, b := cs[i], cs[j]
+	return icmp.Compare(a.imin, b.imin) < 0
+}
+func (cs compactions) Len() int      { return len(cs) }
+func (cs compactions) Swap(i, j int) { cs[i], cs[j] = cs[j], cs[i] }
+
+// Helper type for sortByKey.
+type compactionsSortByKey struct {
+	compactions
+	icmp *iComparer
+}
+
+func (x *compactionsSortByKey) Less(i, j int) bool {
+	return x.lessByKey(x.icmp, i, j)
+}
+
+type compactionContext struct {
+	sorted   map[int][]*compaction
+	fifo     map[int][]*compaction
+	icmp     *iComparer
+	noseek   bool
+	denylist map[int]struct{}
+}
+
+func (ctx *compactionContext) add(c *compaction) {
+	ctx.sorted[c.sourceLevel] = append(ctx.sorted[c.sourceLevel], c)
+	sort.Sort(&compactionsSortByKey{
+		compactions: ctx.sorted[c.sourceLevel],
+		icmp:        ctx.icmp,
+	})
+	ctx.fifo[c.sourceLevel] = append(ctx.fifo[c.sourceLevel], c)
+}
+
+func (ctx *compactionContext) delete(c *compaction) {
+	for index, comp := range ctx.sorted[c.sourceLevel] {
+		if comp == c {
+			ctx.sorted[c.sourceLevel] = append(ctx.sorted[c.sourceLevel][:index], ctx.sorted[c.sourceLevel][index+1:]...)
+			break
+		}
+	}
+	for index, comp := range ctx.fifo[c.sourceLevel] {
+		if comp == c {
+			ctx.fifo[c.sourceLevel] = append(ctx.fifo[c.sourceLevel][:index], ctx.fifo[c.sourceLevel][index+1:]...)
+			break
+		}
+	}
+	ctx.reset(c.sourceLevel)
+	return
+}
+
+// reset resets the denylist and seek flag. If one level-n compaction finishes,
+// then it will re-activate the adjacent levels if they are marked unavailable
+// before. Besides we always re-activate seek compaction.
+func (ctx *compactionContext) reset(level int) {
+	if _, exist := ctx.denylist[level]; exist {
+		delete(ctx.denylist, level)
+	}
+	if _, exist := ctx.denylist[level+1]; exist {
+		delete(ctx.denylist, level+1)
+	}
+	if level > 0 {
+		if _, exist := ctx.denylist[level-1]; exist {
+			delete(ctx.denylist, level-1)
+		}
+	}
+	ctx.noseek = false
+}
+
+func (ctx *compactionContext) count() int {
+	var total int
+	for _, comps := range ctx.sorted {
+		total += len(comps)
+	}
+	return total
+}
+
+func (ctx *compactionContext) get(level int) []*compaction {
+	return ctx.fifo[level]
+}
+
+func (ctx *compactionContext) getSorted(level int) []*compaction {
+	return ctx.sorted[level]
+}
+
+// removing returns the tables which are acting as the source level input
+// in the ongoing compactions. All returned tables are sorted by keys.
+func (ctx *compactionContext) removing(level int) tFiles {
+	comps := ctx.getSorted(level)
+	var v0 tFiles
+	for _, comp := range comps {
+		v0 = append(v0, comp.levels[0]...)
+	}
+	return v0
+}
+
+// removing returns the tables which are acting as the dest level input
+// in the ongoing compactions. All returned tables are sorted by keys.
+func (ctx *compactionContext) recreating(level int) tFiles {
+	if level == 0 {
+		return nil
+	}
+	comps := ctx.getSorted(level - 1)
+	var v1 tFiles
+	for _, comp := range comps {
+		v1 = append(v1, comp.levels[1]...)
+	}
+	return v1
+}
+
+// tCompaction is the scheduler of table compaction. Here concurrent compactions
+// are allowed and scheduled for best performance. Compaction performance is the
+// bottleneck of the entire system. Slow compaction will eventually lead to write
+// suspension. So this loop will try to maximize the compaction performance by
+// selecting isolated files to compact concurrently.
+//
+// For level0 compaction, concurrency is not allowed. Since we can't guarantee two
+// level0 compactions are non-overlapped. But we do see that level0 compaction in
+// some sense become the bottleneck, it can slow down/suspend write operations if
+// it's not fast enough. Also if level0 compaction can't generate tables fast
+// enough, the non-level0 compactors may become idle.
+//
+// For non-level0 compaction, concurrency is allowed if two compactions are totally
+// isolated.
+//
+// For compaction level selection, it's a little different with single-thread version.
+// Now two factors will be considered to select source level: current version and ongoing
+// compactions. For level0 if there is already one compaction running, then no more level0
+// compaction should be picked. For non-level0, if the total size except the "removing"
+// tables and "recreating" tables still exceeds the threshold, it may be picked.
+// The "removing" tables refers to the tables which are picked as the source level input
+// of ongoing compactions. "recreating" tables refers to the tables which are picked
+// as the dest level input of ongoing compactions.
+//
+// For compaction file selection, it's the core of the entire mechanism. For source level
+// we only pick the file which is idle. Idle means it's not the input of other compactions
+// (either level n compactions or level n-1 compactions). It's same when picking files in
+// parent level. In this way we can ensure all compacting files are isolated with each other.
+//
+// But in the parent level, there is one difference. Actually for the file in parent level
+// which is removing(the input of child level compactions), we can just kick them out and mark
+// these compactions as the dependencies. But it will make the code much more complicated.
+// Also consider the concurrency is limited, so we just don't accept this kind of compaction.
 func (db *DB) tCompaction() {
 	var (
-		x     cCmd
-		waitQ []cCmd
-	)
+		// The maximum number of compactions are allowed to run concurrently.
+		// The default value is the CPU core number.
+		compLimit = db.s.o.GetCompactionConcurrency()
 
+		// Compaction context includes all ongoing compactions.
+		ctx = &compactionContext{
+			sorted:   make(map[int][]*compaction),
+			fifo:     make(map[int][]*compaction),
+			icmp:     db.s.icmp,
+			denylist: make(map[int]struct{}),
+		}
+		done  = make(chan *compaction)
+		subWg sync.WaitGroup
+
+		// Various waiting list
+		x        cCmd
+		waitQ    []cCmd // Waiting list will be activated if the level0 tables less then threshold
+		waitAll  []cCmd // Waiting list will be activated iff all compactions have finished.
+		rangeCmd cCmd   // Single range compaction waiting channel
+	)
 	defer func() {
+		// Panic catcher for potential range compaction.
+		// For all other compactions the panic will be
+		// caught in their own routine.
 		if x := recover(); x != nil {
 			if x != errCompactionTransactExiting {
 				panic(x)
 			}
 		}
+		subWg.Wait()
 		for i := range waitQ {
 			waitQ[i].ack(ErrClosed)
 			waitQ[i] = nil
 		}
+		for i := range waitAll {
+			waitAll[i].ack(ErrClosed)
+			waitAll[i] = nil
+		}
 		if x != nil {
 			x.ack(ErrClosed)
+		}
+		if rangeCmd != nil {
+			rangeCmd.ack(ErrClosed)
 		}
 		db.closeW.Done()
 	}()
 
 	for {
-		if db.tableNeedCompaction() {
-			select {
-			case x = <-db.tcompCmdC:
-			case ch := <-db.tcompPauseC:
-				db.pauseCompaction(ch)
-				continue
-			case <-db.closeC:
-				return
-			default:
-			}
-			// Resume write operation as soon as possible.
-			if len(waitQ) > 0 && db.resumeWrite() {
-				for i := range waitQ {
-					waitQ[i].ack(nil)
-					waitQ[i] = nil
-				}
-				waitQ = waitQ[:0]
-			}
-		} else {
+		// Send ack signal to all waiting channels for resuming
+		// db operation(e.g. writes).
+		if len(waitQ) > 0 && db.resumeWrite() {
 			for i := range waitQ {
 				waitQ[i].ack(nil)
 				waitQ[i] = nil
 			}
 			waitQ = waitQ[:0]
+		}
+		var (
+			needCompact bool
+			level       int
+			table       *tFile
+		)
+		if ctx.count() < compLimit && rangeCmd == nil {
+			needCompact, level, table = db.tableNeedCompaction(ctx)
+		}
+		if needCompact {
 			select {
-			case x = <-db.tcompCmdC:
-			case ch := <-db.tcompPauseC:
-				db.pauseCompaction(ch)
-				continue
 			case <-db.closeC:
 				return
+			case x = <-db.tcompCmdC:
+			//case ch := <-db.tcompPauseC:
+			//	db.pauseCompaction(ch)
+			//	continue
+			case c := <-done:
+				ctx.delete(c)
+				continue
+			default:
+			}
+		} else {
+			// If there is a pending range compaction, do it right now
+			if rangeCmd != nil && ctx.count() == 0 {
+				cmd := rangeCmd.(cRange)
+				cmd.ack(db.tableRangeCompaction(cmd.level, cmd.min, cmd.max))
+				rangeCmd = nil
+				continue // Re-loop is necessary, try to spin up more compactions
+			}
+			// If the waitAll list is not empty, send the ack if all compactions have finished.
+			if len(waitAll) != 0 && ctx.count() == 0 {
+				for _, wait := range waitAll {
+					wait.ack(nil)
+					wait = nil
+				}
+				waitAll = waitAll[:0]
+			}
+			select {
+			case <-db.closeC:
+				return
+			case x = <-db.tcompCmdC:
+			//case ch := <-db.tcompPauseC:
+			//	db.pauseCompaction(ch)
+			//	continue
+			case c := <-done:
+				ctx.delete(c)
+				continue
 			}
 		}
 		if x != nil {
 			switch cmd := x.(type) {
 			case cAuto:
-				if cmd.ackC != nil {
-					// Check the write pause state before caching it.
-					if db.resumeWrite() {
-						x.ack(nil)
-					} else {
-						waitQ = append(waitQ, x)
-					}
+				if cmd.full {
+					waitAll = append(waitAll, cmd)
+				} else if cmd.ackC != nil {
+					waitQ = append(waitQ, x)
 				}
 			case cRange:
-				x.ack(db.tableRangeCompaction(cmd.level, cmd.min, cmd.max))
+				if ctx.count() > 0 {
+					rangeCmd = x
+				} else {
+					x.ack(db.tableRangeCompaction(cmd.level, cmd.min, cmd.max))
+				}
 			default:
 				panic("leveldb: unknown command")
 			}
 			x = nil
+			continue
 		}
-		db.tableAutoCompaction()
+		db.runCompaction(ctx, level, table, &subWg, done)
 	}
+}
+
+func (db *DB) runCompaction(ctx *compactionContext, level int, table *tFile, wg *sync.WaitGroup, done chan *compaction) {
+	var c *compaction
+	if table == nil {
+		c = db.s.pickCompactionByLevel(level, ctx)
+		if c == nil {
+			// We can't pick one more isolated compaction in level n.
+			// Mark the entire level as unavailable. In theory it shouldn't
+			// happen a lot.
+			ctx.denylist[level] = struct{}{}
+			return
+		}
+	} else {
+		c = db.s.pickCompactionByTable(level, table, ctx)
+		if c == nil {
+			// The involved tables are not available now. Mark the seek
+			// compaction as unavailable.
+			ctx.noseek = true
+			return
+		}
+	}
+	ctx.add(c)
+	wg.Add(1)
+
+	go func() {
+		// Catch the panic in its own goroutine.
+		defer func() {
+			if x := recover(); x != nil {
+				if x != errCompactionTransactExiting {
+					panic(x)
+				}
+			}
+		}()
+		defer wg.Done()
+
+		db.tableCompaction(c, false, func(c *compaction) {
+			select {
+			case done <- c:
+			case <-db.closeC:
+			}
+		})
+	}()
 }

--- a/leveldb/db_compaction_test.go
+++ b/leveldb/db_compaction_test.go
@@ -1,0 +1,103 @@
+// Copyright (c) 2020, Suryandaru Triandana <syndtr@gmail.com>
+// All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package leveldb
+
+import (
+	"testing"
+
+	"github.com/syndtr/goleveldb/leveldb/comparer"
+)
+
+func increseKey(key []byte) []byte {
+	for i := len(key) - 1; i >= 0; i-- {
+		key[i]++
+		if key[i] != 0x0 {
+			break
+		}
+	}
+	return key
+}
+
+func copyBytes(b []byte) (copiedBytes []byte) {
+	if b == nil {
+		return nil
+	}
+	copiedBytes = make([]byte, len(b))
+	copy(copiedBytes, b)
+	return
+}
+
+func testCompaction(level int, sn int, start internalKey) *compaction {
+	var (
+		source tFiles
+		parent tFiles
+	)
+	for i := 0; i < sn; i++ {
+		imin := copyBytes(start)
+		for j := 0; j < 2*i; j++ {
+			increseKey(imin)
+		}
+		imax := increseKey(copyBytes(imin))
+		source = append(source, &tFile{imin: makeInternalKey(nil, imin, 1, keyTypeVal), imax: makeInternalKey(nil, imax, 1, keyTypeVal)})
+	}
+	parent = append(parent, &tFile{imin: start, imax: source[len(source)-1].imax})
+	return &compaction{
+		sourceLevel: level,
+		levels:      [2]tFiles{source, parent},
+		imin:        source[0].imin,
+		imax:        source[len(source)-1].imax,
+	}
+}
+
+func TestCompactionContext(t *testing.T) {
+	icmp := &iComparer{comparer.DefaultComparer}
+	ctx := &compactionContext{
+		sorted:   make(map[int][]*compaction),
+		fifo:     make(map[int][]*compaction),
+		icmp:     icmp,
+		noseek:   false,
+		denylist: make(map[int]struct{}),
+	}
+	var comps []*compaction
+	comps = append(comps, testCompaction(1, 2, []byte{0x00, 0x01}))
+	comps = append(comps, testCompaction(1, 2, []byte{0x00, 0x21}))
+	comps = append(comps, testCompaction(1, 2, []byte{0x00, 0x11}))
+	comps = append(comps, testCompaction(2, 2, []byte{0x00, 0x01}))
+	comps = append(comps, testCompaction(2, 2, []byte{0x00, 0x11}))
+
+	for _, c := range comps {
+		ctx.add(c)
+	}
+	level1 := ctx.getSorted(1)
+	for i := 0; i < len(level1)-1; i++ {
+		if icmp.Compare(level1[i].imax, level1[i+1].imax) >= 0 {
+			t.Fatalf("Unsorted compaction")
+		}
+	}
+	removing := ctx.removing(1)
+	if len(removing) != 6 {
+		t.Fatalf("Incorrect removing file number")
+	}
+	recreating := ctx.recreating(1)
+	if len(recreating) != 0 {
+		t.Fatalf("Incorrect recreating file number")
+	}
+	removing = ctx.removing(2)
+	if len(removing) != 4 {
+		t.Fatalf("Incorrect removing file number")
+	}
+	recreating = ctx.recreating(2)
+	if len(recreating) != 3 {
+		t.Fatalf("Incorrect recreating file number")
+	}
+	for _, c := range comps {
+		ctx.delete(c)
+	}
+	if ctx.count() != 0 {
+		t.Fatalf("Failed to delete all compactions")
+	}
+}

--- a/leveldb/db_test.go
+++ b/leveldb/db_test.go
@@ -342,7 +342,7 @@ func (h *dbHarness) getKeyVal(want string) {
 func (h *dbHarness) waitCompaction() {
 	t := h.t
 	db := h.db
-	if err := db.compTriggerWait(db.tcompCmdC); err != nil {
+	if err := db.waitAllTableComp(); err != nil {
 		t.Error("compaction error: ", err)
 	}
 }
@@ -2565,7 +2565,7 @@ func TestDB_TableCompactionBuilder(t *testing.T) {
 
 	// Build grandparent.
 	v := s.version()
-	c := newCompaction(s, v, 1, append(tFiles{}, v.levels[1]...), undefinedCompaction)
+	c := newCompaction(s, v, 1, append(tFiles{}, v.levels[1]...), undefinedCompaction, nil)
 	rec := &sessionRecord{}
 	b := &tableCompactionBuilder{
 		s:         s,
@@ -2589,7 +2589,7 @@ func TestDB_TableCompactionBuilder(t *testing.T) {
 
 	// Build level-1.
 	v = s.version()
-	c = newCompaction(s, v, 0, append(tFiles{}, v.levels[0]...), undefinedCompaction)
+	c = newCompaction(s, v, 0, append(tFiles{}, v.levels[0]...), undefinedCompaction, nil)
 	rec = &sessionRecord{}
 	b = &tableCompactionBuilder{
 		s:         s,
@@ -2633,7 +2633,7 @@ func TestDB_TableCompactionBuilder(t *testing.T) {
 
 	// Compaction with transient error.
 	v = s.version()
-	c = newCompaction(s, v, 1, append(tFiles{}, v.levels[1]...), undefinedCompaction)
+	c = newCompaction(s, v, 1, append(tFiles{}, v.levels[1]...), undefinedCompaction, nil)
 	rec = &sessionRecord{}
 	b = &tableCompactionBuilder{
 		s:         s,

--- a/leveldb/opt/options.go
+++ b/leveldb/opt/options.go
@@ -9,6 +9,7 @@ package opt
 
 import (
 	"math"
+	"runtime"
 
 	"github.com/syndtr/goleveldb/leveldb/cache"
 	"github.com/syndtr/goleveldb/leveldb/comparer"
@@ -240,6 +241,12 @@ type Options struct {
 	//
 	// The default value is nil.
 	CompactionTotalSizeMultiplierPerLevel []float64
+
+	// CompactionConcurrency defines the maximum compaction concurrency allowed
+	// in the system.
+	//
+	// The default value is CPU core number.
+	CompactionConcurrency int
 
 	// Comparer defines a total ordering over the space of []byte keys: a 'less
 	// than' relationship. The same comparison algorithm must be used for reads
@@ -493,6 +500,13 @@ func (o *Options) GetCompactionTotalSize(level int) int64 {
 		mult = math.Pow(DefaultCompactionTotalSizeMultiplier, float64(level))
 	}
 	return int64(float64(base) * mult)
+}
+
+func (o *Options) GetCompactionConcurrency() int {
+	if o != nil || o.CompactionConcurrency <= 0 {
+		return runtime.NumCPU()
+	}
+	return o.CompactionConcurrency
 }
 
 func (o *Options) GetComparer() comparer.Comparer {

--- a/leveldb/session.go
+++ b/leveldb/session.go
@@ -52,9 +52,11 @@ type session struct {
 	manifestWriter storage.Writer
 	manifestFd     storage.FileDesc
 
-	stCompPtrs  []internalKey // compaction pointers; need external synchronization
-	stVersion   *version      // current version
-	ntVersionId int64         // next version id to assign
+	compLock   sync.RWMutex  //  Lock used to protect stCompPtrs
+	stCompPtrs []internalKey // compaction pointers
+
+	stVersion   *version // current version
+	ntVersionId int64    // next version id to assign
 	refCh       chan *vTask
 	relCh       chan *vTask
 	deltaCh     chan *vDelta

--- a/leveldb/session_compaction.go
+++ b/leveldb/session_compaction.go
@@ -8,7 +8,6 @@ package leveldb
 
 import (
 	"sort"
-	"sync/atomic"
 
 	"github.com/syndtr/goleveldb/leveldb/iterator"
 	"github.com/syndtr/goleveldb/leveldb/memdb"
@@ -52,46 +51,131 @@ func (s *session) flushMemdb(rec *sessionRecord, mdb *memdb.DB, maxLevel int) (i
 	return flushLevel, nil
 }
 
-// Pick a compaction based on current state; need external synchronization.
-func (s *session) pickCompaction() *compaction {
-	v := s.version()
-
-	var sourceLevel int
-	var t0 tFiles
-	var typ int
-	if v.cScore >= 1 {
-		sourceLevel = v.cLevel
-		cptr := s.getCompPtr(sourceLevel)
-		tables := v.levels[sourceLevel]
-		if cptr != nil && sourceLevel > 0 {
-			n := len(tables)
-			if i := sort.Search(n, func(i int) bool {
-				return s.icmp.Compare(tables[i].imax, cptr) > 0
-			}); i < n {
-				t0 = append(t0, tables[i])
+// pickFirst picks the seed file for compaction if there is no ongoing compaction
+// in this level. The pick algorithm is very simple: select the first file with the
+// max key greater than compPtr as the seed file. If the compPtr is nil, than pick
+// the first one.
+func (s *session) pickFirst(level int, v *version, ctx *compactionContext) *compaction {
+	var (
+		cptr   = s.getCompPtr(level)
+		tables = v.levels[level]
+	)
+	typ := level0Compaction
+	if level != 0 {
+		typ = nonLevel0Compaction
+	}
+	// If it's level0 compaction(file overlapped) or the cptr is nil,
+	// iterate from the beginning.
+	if level == 0 || cptr == nil {
+		for _, t := range tables {
+			c := newCompaction(s, v, level, tFiles{t}, typ, ctx)
+			if c != nil {
+				return c
 			}
 		}
-		if len(t0) == 0 {
-			t0 = append(t0, tables[0])
-		}
-		if sourceLevel == 0 {
-			typ = level0Compaction
-		} else {
-			typ = nonLevel0Compaction
-		}
-	} else {
-		if p := atomic.LoadPointer(&v.cSeek); p != nil {
-			ts := (*tSet)(p)
-			sourceLevel = ts.level
-			t0 = append(t0, ts.table)
-			typ = seekCompaction
-		} else {
-			v.release()
-			return nil
+		return nil
+	}
+	// Binary search the proper start position
+	start := sort.Search(len(tables), func(i int) bool {
+		return s.icmp.Compare(tables[i].imax, cptr) > 0
+	})
+	for i := start; i < len(tables); i++ {
+		c := newCompaction(s, v, level, tFiles{tables[i]}, typ, ctx)
+		if c != nil {
+			return c
 		}
 	}
+	for i := 0; i < start; i++ {
+		c := newCompaction(s, v, level, tFiles{tables[i]}, typ, ctx)
+		if c != nil {
+			return c
+		}
+	}
+	return nil
+}
 
-	return newCompaction(s, v, sourceLevel, t0, typ)
+// pickMore picks the seed file for compaction if there are ongoing compactions
+// in this level.
+func (s *session) pickMore(level int, v *version, ctx *compactionContext) *compaction {
+	var (
+		reverse      bool
+		start, limit internalKey
+	)
+	typ := level0Compaction
+	if level != 0 {
+		typ = nonLevel0Compaction
+	}
+	cs := ctx.get(level)
+	if len(cs) == 0 {
+		return nil // Should never happen
+	}
+
+	limit = cs[len(cs)-1].imax
+	start = cs[0].imax
+	if s.icmp.Compare(start, limit) > 0 {
+		reverse = true
+		start, limit = limit, start
+	}
+
+	tables := v.levels[level]
+	if !reverse {
+		p := sort.Search(len(tables), func(i int) bool {
+			return s.icmp.Compare(tables[i].imax, limit) > 0
+		})
+		for i := p; i < len(tables); i++ {
+			c := newCompaction(s, v, level, tFiles{tables[i]}, typ, ctx)
+			if c != nil {
+				return c
+			}
+		}
+		for _, t := range tables {
+			if s.icmp.Compare(t.imax, start) >= 0 {
+				break
+			}
+			c := newCompaction(s, v, level, tFiles{t}, typ, ctx)
+			if c != nil {
+				return c
+			}
+		}
+		return nil
+	} else {
+		p := sort.Search(len(tables), func(i int) bool {
+			return s.icmp.Compare(tables[i].imax, start) > 0
+		})
+		for i := p; i < len(tables); i++ {
+			if s.icmp.Compare(tables[i].imax, limit) >= 0 {
+				break
+			}
+			c := newCompaction(s, v, level, tFiles{tables[i]}, typ, ctx)
+			if c != nil {
+				return c
+			}
+		}
+		return nil
+	}
+}
+
+func (s *session) pickCompactionByLevel(level int, ctx *compactionContext) (comp *compaction) {
+	v := s.version()
+	defer func() {
+		if comp == nil {
+			v.release()
+		}
+	}()
+	if len(ctx.get(level)) == 0 {
+		return s.pickFirst(level, v, ctx)
+	}
+	return s.pickMore(level, v, ctx)
+}
+
+func (s *session) pickCompactionByTable(level int, table *tFile, ctx *compactionContext) (comp *compaction) {
+	v := s.version()
+	defer func() {
+		if comp == nil {
+			v.release()
+		}
+	}()
+	return newCompaction(s, v, level, []*tFile{table}, seekCompaction, ctx)
 }
 
 // Create compaction from given level and range; need external synchronization.
@@ -130,10 +214,10 @@ func (s *session) getCompactionRange(sourceLevel int, umin, umax []byte, noLimit
 	if sourceLevel != 0 {
 		typ = nonLevel0Compaction
 	}
-	return newCompaction(s, v, sourceLevel, t0, typ)
+	return newCompaction(s, v, sourceLevel, t0, typ, nil)
 }
 
-func newCompaction(s *session, v *version, sourceLevel int, t0 tFiles, typ int) *compaction {
+func newCompaction(s *session, v *version, sourceLevel int, t0 tFiles, typ int, ctx *compactionContext) *compaction {
 	c := &compaction{
 		s:             s,
 		v:             v,
@@ -143,7 +227,9 @@ func newCompaction(s *session, v *version, sourceLevel int, t0 tFiles, typ int) 
 		maxGPOverlaps: int64(s.o.GetCompactionGPOverlaps(sourceLevel)),
 		tPtrs:         make([]int, len(v.levels)),
 	}
-	c.expand()
+	if !c.expand(ctx) {
+		return nil
+	}
 	c.save()
 	return c
 }
@@ -153,6 +239,7 @@ type compaction struct {
 	s *session
 	v *version
 
+	id            int64
 	typ           int
 	sourceLevel   int
 	levels        [2]tFiles
@@ -194,7 +281,7 @@ func (c *compaction) release() {
 }
 
 // Expand compacted tables; need external synchronization.
-func (c *compaction) expand() {
+func (c *compaction) expand(ctx *compactionContext) bool {
 	limit := int64(c.s.o.GetCompactionExpandLimit(c.sourceLevel))
 	vt0 := c.v.levels[c.sourceLevel]
 	vt1 := tFiles{}
@@ -203,46 +290,77 @@ func (c *compaction) expand() {
 	}
 
 	t0, t1 := c.levels[0], c.levels[1]
-	imin, imax := t0.getRange(c.s.icmp)
+	imin, imax := t0.getRange(c.s.icmp, c.sourceLevel == 0)
 
 	// For non-zero levels, the ukey can't hop across tables at all.
 	if c.sourceLevel == 0 {
 		// We expand t0 here just incase ukey hop across tables.
-		t0 = vt0.getOverlaps(t0, c.s.icmp, imin.ukey(), imax.ukey(), c.sourceLevel == 0)
+		t0 = vt0.getOverlaps(t0, c.s.icmp, imin.ukey(), imax.ukey(), true)
 		if len(t0) != len(c.levels[0]) {
-			imin, imax = t0.getRange(c.s.icmp)
+			imin, imax = t0.getRange(c.s.icmp, true)
+		}
+	}
+	if c.sourceLevel != 0 && ctx != nil {
+		// Ensure the source level files are not the input of other compactions.
+		if ctx.removing(c.sourceLevel).hasFiles(t0) {
+			return false
+		}
+		if ctx.recreating(c.sourceLevel).hasFiles(t0) {
+			return false
 		}
 	}
 	t1 = vt1.getOverlaps(t1, c.s.icmp, imin.ukey(), imax.ukey(), false)
+
+	// If the overlapped tables in level n+1 are not available, abort the expansion
+	if ctx != nil {
+		if ctx.recreating(c.sourceLevel + 1).hasFiles(t1) {
+			return false
+		}
+		if ctx.removing(c.sourceLevel + 1).hasFiles(t1) {
+			return false
+		}
+	}
 	// Get entire range covered by compaction.
-	amin, amax := append(t0, t1...).getRange(c.s.icmp)
+	amin, amax := append(t0, t1...).getRange(c.s.icmp, true)
 
 	// See if we can grow the number of inputs in "sourceLevel" without
 	// changing the number of "sourceLevel+1" files we pick up.
 	if len(t1) > 0 {
 		exp0 := vt0.getOverlaps(nil, c.s.icmp, amin.ukey(), amax.ukey(), c.sourceLevel == 0)
 		if len(exp0) > len(t0) && t1.size()+exp0.size() < limit {
-			xmin, xmax := exp0.getRange(c.s.icmp)
-			exp1 := vt1.getOverlaps(nil, c.s.icmp, xmin.ukey(), xmax.ukey(), false)
-			if len(exp1) == len(t1) {
-				c.s.logf("table@compaction expanding L%d+L%d (F·%d S·%s)+(F·%d S·%s) -> (F·%d S·%s)+(F·%d S·%s)",
-					c.sourceLevel, c.sourceLevel+1, len(t0), shortenb(int(t0.size())), len(t1), shortenb(int(t1.size())),
-					len(exp0), shortenb(int(exp0.size())), len(exp1), shortenb(int(exp1.size())))
-				imin, imax = xmin, xmax
-				t0, t1 = exp0, exp1
-				amin, amax = append(t0, t1...).getRange(c.s.icmp)
+			var skip bool
+			if ctx != nil {
+				skip = ctx.removing(c.sourceLevel).hasFiles(exp0) || ctx.recreating(c.sourceLevel).hasFiles(exp0)
+			}
+			if !skip {
+				xmin, xmax := exp0.getRange(c.s.icmp, c.sourceLevel == 0)
+				exp1 := vt1.getOverlaps(nil, c.s.icmp, xmin.ukey(), xmax.ukey(), false)
+				if len(exp1) == len(t1) {
+					c.s.logf("table@compaction expanding L%d+L%d (F·%d S·%s)+(F·%d S·%s) -> (F·%d S·%s)+(F·%d S·%s)",
+						c.sourceLevel, c.sourceLevel+1, len(t0), shortenb(int(t0.size())), len(t1), shortenb(int(t1.size())),
+						len(exp0), shortenb(int(exp0.size())), len(exp1), shortenb(int(exp1.size())))
+					imin, imax = xmin, xmax
+					t0, t1 = exp0, exp1
+					amin, amax = append(t0, t1...).getRange(c.s.icmp, c.sourceLevel == 0)
+				}
 			}
 		}
 	}
 
 	// Compute the set of grandparent files that overlap this compaction
 	// (parent == sourceLevel+1; grandparent == sourceLevel+2)
+	//
+	// Note the tables overlapped in the grandparent level may are removing.
+	// We don't care about it seems the only downside is we split in tables
+	// in the parent level but actually we don't need.
 	if level := c.sourceLevel + 2; level < len(c.v.levels) {
 		c.gp = c.v.levels[level].getOverlaps(c.gp, c.s.icmp, amin.ukey(), amax.ukey(), false)
 	}
 
 	c.levels[0], c.levels[1] = t0, t1
 	c.imin, c.imax = imin, imax
+
+	return true
 }
 
 // Check whether compaction is trivial.

--- a/leveldb/table.go
+++ b/leveldb/table.go
@@ -276,7 +276,13 @@ func (tf tFiles) getOverlaps(dst tFiles, icmp *iComparer, umin, umax []byte, ove
 }
 
 // Returns tables key range.
-func (tf tFiles) getRange(icmp *iComparer) (imin, imax internalKey) {
+func (tf tFiles) getRange(icmp *iComparer, overlapped bool) (imin, imax internalKey) {
+	if !overlapped {
+		if len(tf) == 0 {
+			return
+		}
+		return tf[0].imin, tf[len(tf)-1].imax
+	}
 	for i, t := range tf {
 		if i == 0 {
 			imin, imax = t.imin, t.imax
@@ -289,8 +295,21 @@ func (tf tFiles) getRange(icmp *iComparer) (imin, imax internalKey) {
 			imax = t.imax
 		}
 	}
-
 	return
+}
+
+func (tf tFiles) hasFiles(fs tFiles) bool {
+	if len(tf) == 0 {
+		return false
+	}
+	for _, f := range fs {
+		for _, t := range tf {
+			if f == t {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // Creates iterator index from tables.

--- a/leveldb/version.go
+++ b/leveldb/version.go
@@ -428,6 +428,10 @@ func (v *version) needCompaction(ctx *compactionContext) (needCompact bool, leve
 	if p := atomic.LoadPointer(&v.cSeek); p != nil && !ctx.noseek {
 		ts := (*tSet)(p)
 
+		// Don't spin anymore level0 compaction if there is one ongoing
+		if ts.level == 0 && ctx != nil && len(ctx.get(0)) > 0 {
+			return false, -1, nil
+		}
 		// Ensure the source table is not picked as the input of level
 		// N compactions or level N-1 compactions.
 		if ctx.removing(ts.level).hasFiles(tFiles{ts.table}) {


### PR DESCRIPTION
This PR implements the concurrent compaction for leveldb.

It's rejected by the original upstream because the author doesn't want to introduce non-trivial PR.

It's basically the main reason for forking the go-leveldb, let's keep the experiment but store the *unmatured*
code in this project.

A few things need to be done before merging:

- Design tests for verifying the correctness
- Have more performance statistic