### PR TITLE
leveldb: impl concurrent range compaction

### DIFF
--- a/leveldb/db.go
+++ b/leveldb/db.go
@@ -1136,6 +1136,12 @@ func (db *DB) SizeOf(ranges []util.Range) (Sizes, error) {
 	return sizes, nil
 }
 
+// StorageFiles is a helper function which should only be used in
+// testing. It can return a list of fds of given file type.
+func (db *DB) StorageFiles(typ storage.FileType) ([]storage.FileDesc, error) {
+	return db.s.stor.List(typ)
+}
+
 // Close closes the DB. This will also releases any outstanding snapshot,
 // abort any in-flight compaction and discard open transaction.
 //

--- a/leveldb/db_compaction.go
+++ b/leveldb/db_compaction.go
@@ -1124,9 +1124,9 @@ func (db *DB) tCompaction() {
 			case <-db.closeC:
 				return
 			case x = <-db.tcompCmdC:
-			case ch := <-db.tcompPauseC:
-				db.pauseCompaction(ch)
-				continue
+			//case ch := <-db.tcompPauseC:
+			//	db.pauseCompaction(ch)
+			//	continue
 			case c := <-done:
 				ctx.delete(c)
 				continue
@@ -1154,9 +1154,9 @@ func (db *DB) tCompaction() {
 			case <-db.closeC:
 				return
 			case x = <-db.tcompCmdC:
-			case ch := <-db.tcompPauseC:
-				db.pauseCompaction(ch)
-				continue
+			//case ch := <-db.tcompPauseC:
+			//	db.pauseCompaction(ch)
+			//	continue
 			case c := <-done:
 				ctx.delete(c)
 				continue

--- a/leveldb/db_compaction.go
+++ b/leveldb/db_compaction.go
@@ -687,13 +687,6 @@ func (db *DB) tableRangeCompactionAt(level int, umin, umax []byte) error {
 		var comp *compaction
 		if ctx.count() < compLimit {
 			comp = db.s.getCompactionRange(ctx, level, umin, umax)
-
-			// If there is no more available tables to compact,
-			// mark the level as denied temporarily until some
-			// other compactions re-activate.
-			if comp == nil {
-				ctx.denylist[level] = struct{}{}
-			}
 		}
 		if comp != nil {
 			select {

--- a/leveldb/db_compaction.go
+++ b/leveldb/db_compaction.go
@@ -1131,9 +1131,9 @@ func (db *DB) tCompaction() {
 			case <-db.closeC:
 				return
 			case x = <-db.tcompCmdC:
-			//case ch := <-db.tcompPauseC:
-			//	db.pauseCompaction(ch)
-			//	continue
+			case ch := <-db.tcompPauseC:
+				db.pauseCompaction(ch)
+				continue
 			case c := <-done:
 				ctx.delete(c)
 				continue
@@ -1159,9 +1159,9 @@ func (db *DB) tCompaction() {
 			case <-db.closeC:
 				return
 			case x = <-db.tcompCmdC:
-			//case ch := <-db.tcompPauseC:
-			//	db.pauseCompaction(ch)
-			//	continue
+			case ch := <-db.tcompPauseC:
+				db.pauseCompaction(ch)
+				continue
 			case c := <-done:
 				ctx.delete(c)
 				continue

--- a/leveldb/db_compaction.go
+++ b/leveldb/db_compaction.go
@@ -642,39 +642,101 @@ func (db *DB) tableCompaction(c *compaction, noTrivial bool, done func(*compacti
 func (db *DB) tableRangeCompaction(level int, umin, umax []byte) error {
 	db.logf("table@compaction range L%d %q:%q", level, umin, umax)
 	if level >= 0 {
-		if c := db.s.getCompactionRange(level, umin, umax, true); c != nil {
-			db.tableCompaction(c, true, nil)
-		}
+		return db.tableRangeCompactionAt(level, umin, umax)
 	} else {
-		// Retry until nothing to compact.
-		for {
-			compacted := false
-
-			// Scan for maximum level with overlapped tables.
-			v := db.s.version()
-			m := 1
-			for i := m; i < len(v.levels); i++ {
-				tables := v.levels[i]
-				if tables.overlaps(db.s.icmp, umin, umax, false) {
-					m = i
-				}
+		// Scan for maximum level with overlapped tables.
+		v := db.s.version()
+		m := 1
+		for i := m; i < len(v.levels); i++ {
+			tables := v.levels[i]
+			if tables.overlaps(db.s.icmp, umin, umax, false) {
+				m = i
 			}
-			v.release()
-
-			for level := 0; level < m; level++ {
-				if c := db.s.getCompactionRange(level, umin, umax, false); c != nil {
-					db.tableCompaction(c, true, nil)
-					compacted = true
-				}
+		}
+		v.release()
+		for i := 0; i < m; i++ {
+			err := db.tableRangeCompactionAt(i, umin, umax)
+			if err != nil {
+				return err
 			}
+		}
+		return nil
+	}
+}
 
-			if !compacted {
-				break
+// tableRangeCompactionAt runs range compaction at the specific level.
+func (db *DB) tableRangeCompactionAt(level int, umin, umax []byte) error {
+	var (
+		// The maximum number of compactions are allowed to run concurrently.
+		// The default value is the CPU core number.
+		compLimit = db.s.o.GetCompactionConcurrency()
+
+		// Compaction context includes all ongoing compactions.
+		ctx = &compactionContext{
+			sorted:   make(map[int][]*compaction),
+			fifo:     make(map[int][]*compaction),
+			icmp:     db.s.icmp,
+			denylist: make(map[int]struct{}),
+		}
+		done  = make(chan *compaction)
+		subWg sync.WaitGroup
+	)
+	defer subWg.Wait()
+
+	for {
+		var comp *compaction
+		if ctx.count() < compLimit {
+			comp = db.s.getCompactionRange(ctx, level, umin, umax)
+
+			// If there is no more available tables to compact,
+			// mark the level as denied temporarily until some
+			// other compactions re-activate.
+			if comp == nil {
+				ctx.denylist[level] = struct{}{}
+			}
+		}
+		if comp != nil {
+			select {
+			case <-db.closeC:
+				return ErrClosed
+			case c := <-done:
+				ctx.delete(c)
+				continue
+			default:
+			}
+			ctx.add(comp)
+			subWg.Add(1)
+			go func() {
+				// Catch the panic in its own goroutine.
+				defer func() {
+					if x := recover(); x != nil {
+						if x != errCompactionTransactExiting {
+							panic(x)
+						}
+					}
+				}()
+				defer subWg.Done()
+
+				db.tableCompaction(comp, true, func(c *compaction) {
+					select {
+					case done <- c:
+					case <-db.closeC:
+					}
+				})
+			}()
+		} else {
+			// All overlapped tables have been merged to the parent level
+			if ctx.count() == 0 {
+				return nil
+			}
+			select {
+			case <-db.closeC:
+				return ErrClosed
+			case c := <-done:
+				ctx.delete(c)
 			}
 		}
 	}
-
-	return nil
 }
 
 // tableNeedCompaction returns the indicator whether system needs compaction.

--- a/leveldb/filter/bloom_test.go
+++ b/leveldb/filter/bloom_test.go
@@ -8,8 +8,9 @@ package filter
 
 import (
 	"encoding/binary"
-	"github.com/go-leveldb/goleveldb/leveldb/util"
 	"testing"
+
+	"github.com/go-leveldb/goleveldb/leveldb/util"
 )
 
 type harness struct {

--- a/leveldb/opt/options.go
+++ b/leveldb/opt/options.go
@@ -503,7 +503,7 @@ func (o *Options) GetCompactionTotalSize(level int) int64 {
 }
 
 func (o *Options) GetCompactionConcurrency() int {
-	if o != nil || o.CompactionConcurrency <= 0 {
+	if o == nil || o.CompactionConcurrency <= 0 {
 		return runtime.NumCPU()
 	}
 	return o.CompactionConcurrency

--- a/leveldb/session_compaction.go
+++ b/leveldb/session_compaction.go
@@ -178,27 +178,21 @@ func (s *session) pickCompactionByTable(level int, table *tFile, ctx *compaction
 	return newCompaction(s, v, level, []*tFile{table}, seekCompaction, ctx)
 }
 
-// Create compaction from given level and range; need external synchronization.
-func (s *session) getCompactionRange(sourceLevel int, umin, umax []byte, noLimit bool) *compaction {
-	v := s.version()
-
-	if sourceLevel >= len(v.levels) {
-		v.release()
-		return nil
-	}
-
+func (s *session) getFirstRange(v *version, ctx *compactionContext, sourceLevel int, umin, umax []byte, typ int, limit int64) (comp *compaction) {
+	defer func() {
+		if comp == nil {
+			v.release()
+		}
+	}()
 	t0 := v.levels[sourceLevel].getOverlaps(nil, s.icmp, umin, umax, sourceLevel == 0)
 	if len(t0) == 0 {
-		v.release()
 		return nil
 	}
-
 	// Avoid compacting too much in one shot in case the range is large.
 	// But we cannot do this for level-0 since level-0 files can overlap
 	// and we must not pick one file and drop another older file if the
 	// two files overlap.
-	if !noLimit && sourceLevel > 0 {
-		limit := int64(v.s.o.GetCompactionSourceLimit(sourceLevel))
+	if sourceLevel != 0 {
 		total := int64(0)
 		for i, t := range t0 {
 			total += t.size
@@ -209,12 +203,96 @@ func (s *session) getCompactionRange(sourceLevel int, umin, umax []byte, noLimit
 			}
 		}
 	}
+	return newCompaction(s, v, sourceLevel, t0, typ, ctx)
+}
 
+func (s *session) getMoreRange(v *version, ctx *compactionContext, sourceLevel int, umin, umax []byte, typ int, sourceLimit int64) (comp *compaction) {
+	defer func() {
+		if comp == nil {
+			v.release()
+		}
+	}()
+
+	// Determine the search space for next potential range compaction
+	cs := ctx.get(sourceLevel)
+	if len(cs) == 0 {
+		return nil // Should never happen
+	}
+	limit := cs[len(cs)-1].imax
+	start := cs[0].imax
+
+	var reverse bool
+	if s.icmp.Compare(start, limit) > 0 {
+		reverse = true
+		start, limit = limit, start
+	}
+
+	t0 := v.levels[sourceLevel].getOverlaps(nil, s.icmp, umin, umax, sourceLevel == 0)
+	if len(t0) == 0 {
+		return nil
+	}
+
+	if !reverse {
+		p := sort.Search(len(t0), func(i int) bool {
+			return s.icmp.Compare(t0[i].imax, limit) > 0
+		})
+		for i := p; i < len(t0); i++ {
+			c := newCompaction(s, v, sourceLevel, tFiles{t0[i]}, typ, ctx)
+			if c != nil {
+				// todo try to expand the source files
+				return c
+			}
+		}
+		for _, t := range t0 {
+			if s.icmp.Compare(t.imax, start) >= 0 {
+				break
+			}
+			c := newCompaction(s, v, sourceLevel, tFiles{t}, typ, ctx)
+			if c != nil {
+				// todo try to expand the source files
+				return c
+			}
+		}
+		return nil
+	} else {
+		p := sort.Search(len(t0), func(i int) bool {
+			return s.icmp.Compare(t0[i].imax, start) > 0
+		})
+		for i := p; i < len(t0); i++ {
+			if s.icmp.Compare(t0[i].imax, limit) >= 0 {
+				break
+			}
+			c := newCompaction(s, v, sourceLevel, tFiles{t0[i]}, typ, ctx)
+			if c != nil {
+				// todo try to expand the source files
+				return c
+			}
+		}
+		return nil
+	}
+}
+
+// Create compaction from given level and range; need external synchronization.
+func (s *session) getCompactionRange(ctx *compactionContext, sourceLevel int, umin, umax []byte) *compaction {
+	v := s.version()
+
+	if sourceLevel >= len(v.levels) {
+		v.release()
+		return nil
+	}
 	typ := level0Compaction
 	if sourceLevel != 0 {
 		typ = nonLevel0Compaction
 	}
-	return newCompaction(s, v, sourceLevel, t0, typ, nil)
+	limit := int64(v.s.o.GetCompactionSourceLimit(sourceLevel))
+	if ctx.count() == 0 {
+		return s.getFirstRange(v, ctx, sourceLevel, umin, umax, typ, limit)
+	}
+	if sourceLevel == 0 {
+		v.release()
+		return nil
+	}
+	return s.getMoreRange(v, ctx, sourceLevel, umin, umax, typ, limit)
 }
 
 func newCompaction(s *session, v *version, sourceLevel int, t0 tFiles, typ int, ctx *compactionContext) *compaction {

--- a/leveldb/session_compaction.go
+++ b/leveldb/session_compaction.go
@@ -239,7 +239,6 @@ func (s *session) getMoreRange(v *version, ctx *compactionContext, sourceLevel i
 		for i := p; i < len(t0); i++ {
 			c := newCompaction(s, v, sourceLevel, tFiles{t0[i]}, typ, ctx)
 			if c != nil {
-				// todo try to expand the source files
 				return c
 			}
 		}
@@ -249,7 +248,6 @@ func (s *session) getMoreRange(v *version, ctx *compactionContext, sourceLevel i
 			}
 			c := newCompaction(s, v, sourceLevel, tFiles{t}, typ, ctx)
 			if c != nil {
-				// todo try to expand the source files
 				return c
 			}
 		}
@@ -264,7 +262,6 @@ func (s *session) getMoreRange(v *version, ctx *compactionContext, sourceLevel i
 			}
 			c := newCompaction(s, v, sourceLevel, tFiles{t0[i]}, typ, ctx)
 			if c != nil {
-				// todo try to expand the source files
 				return c
 			}
 		}

--- a/leveldb/storage.go
+++ b/leveldb/storage.go
@@ -1,8 +1,9 @@
 package leveldb
 
 import (
-	"github.com/go-leveldb/goleveldb/leveldb/storage"
 	"sync/atomic"
+
+	"github.com/go-leveldb/goleveldb/leveldb/storage"
 )
 
 type iStorage struct {

--- a/leveldb/table_test.go
+++ b/leveldb/table_test.go
@@ -12,9 +12,9 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/onsi/gomega"
 	"github.com/go-leveldb/goleveldb/leveldb/storage"
 	"github.com/go-leveldb/goleveldb/leveldb/testutil"
+	"github.com/onsi/gomega"
 )
 
 func TestGetOverlaps(t *testing.T) {

--- a/leveldb/version_test.go
+++ b/leveldb/version_test.go
@@ -8,9 +8,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/onsi/gomega"
 	"github.com/go-leveldb/goleveldb/leveldb/storage"
 	"github.com/go-leveldb/goleveldb/leveldb/testutil"
+	"github.com/onsi/gomega"
 )
 
 type testFileRec struct {

--- a/manualtest/dbstress/main.go
+++ b/manualtest/dbstress/main.go
@@ -36,7 +36,7 @@ var (
 	numKeys                = arrayInt{100000, 1332, 531, 1234, 9553, 1024, 35743}
 	httpProf               = "127.0.0.1:5454"
 	transactionProb        = 0.5
-	rangeCompProb          = 0.05
+	rangeCompProb          = 0.005
 	enableBlockCache       = false
 	enableCompression      = false
 	enableBufferPool       = false
@@ -464,8 +464,12 @@ func main() {
 				Start: nil,
 				Limit: limit,
 			}})
+			var size int64
+			if len(totalSize) > 0 {
+				size = totalSize[0]
+			}
 			log.Printf("> BlockCache=%s OpenedTables=%s AliveSnaps=%s AliveIter=%s BlockPool=%q WriteDelay=%q IOStats=%q CompCount=%q Tables=%d TotalSize=%s",
-				cachedblock, openedtables, alivesnaps, aliveiters, blockpool, writeDelay, ioStats, compCount, len(fds), shortenb(int(totalSize[0])))
+				cachedblock, openedtables, alivesnaps, aliveiters, blockpool, writeDelay, ioStats, compCount, len(fds), shortenb(int(size)))
 			log.Print("------------------------")
 		}
 	}()

--- a/manualtest/dbstress/main.go
+++ b/manualtest/dbstress/main.go
@@ -641,7 +641,9 @@ func main() {
 					if mrand.Float64() < rangeCompProb {
 						compRange := dataNsSlice(byte(ns))
 						if err := db.CompactRange(*compRange); err != nil {
-							fatalf(err, "[%02d] RANGE COMPACTION FAILED: %v", ns, err)
+							if err != leveldb.ErrClosed {
+								fatalf(err, "[%02d] RANGE COMPACTION FAILED: %v", ns, err)
+							}
 						}
 					}
 				}

--- a/manualtest/dbstress/main.go
+++ b/manualtest/dbstress/main.go
@@ -36,7 +36,7 @@ var (
 	numKeys                = arrayInt{100000, 1332, 531, 1234, 9553, 1024, 35743}
 	httpProf               = "127.0.0.1:5454"
 	transactionProb        = 0.5
-	rangeCompProb          = 0.5
+	rangeCompProb          = 0.05
 	enableBlockCache       = false
 	enableCompression      = false
 	enableBufferPool       = false


### PR DESCRIPTION
This PR implements the concurrent range compaction.

Range compaction is quite useful when users want to delete a range of data and erase from
the disk immediately. However the original range compaction is single threaded.

Actually, the range compaction is also concurrent-friendly. Except the level0 range compaction,
all other level range compactions can be done in a concurrent way which is identical to normal
compaction.

TODO:

- [ ] Implement the benchmark for more performance proofs
- [x] Run stress test to ensure the code correctness 